### PR TITLE
enforce correct api use

### DIFF
--- a/patch-db/Cargo.toml
+++ b/patch-db/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.1.0"
 [features]
 debug = ["tracing"]
 trace = ["debug", "tracing-error"]
+unstable = []
 
 [dependencies]
 async-trait = "0.1.42"

--- a/patch-db/src/locker.rs
+++ b/patch-db/src/locker.rs
@@ -325,6 +325,9 @@ impl LockOrderEnforcer {
         //
         // Sequences
         // LockRequest >> LockRequest
+        #[cfg(not(feature = "unstable"))]
+        return Ok(());
+        #[cfg(feature = "unstable")]
         match self.locks_held.get(&req.handle_id) {
             None => Ok(()),
             Some(m) => {

--- a/patch-db/src/locker.rs
+++ b/patch-db/src/locker.rs
@@ -420,14 +420,14 @@ impl LockOrderEnforcer {
         match self.locks_held.remove_with_key(&req.handle_id) {
             None => {
                 #[cfg(feature = "tracing")]
-                tracing::warn!("Invalid removal from session manager: {}", req);
+                tracing::warn!("Invalid removal from session manager: {:?}", req);
             }
             Some((hdl, mut locks)) => {
                 let k = (req.ptr.clone(), req.ty);
                 match locks.remove_with_key(&k) {
                     None => {
                         #[cfg(feature = "tracing")]
-                        tracing::warn!("Invalid removal from session manager: {}", req);
+                        tracing::warn!("Invalid removal from session manager: {:?}", req);
                     }
                     Some((k, n)) => {
                         if n - 1 > 0 {


### PR DESCRIPTION
1. introduces a new data structure to track which sessions hold which locks
2. Rejects LockTaxonomyEscalation: `/a/b -> /a`
3. Rejects LockTypeEscalation: `R -> W`
4. Rejects NonCanonicalOrdering: `/a/b -> /a/a`