### PR TITLE
fix: Remove an unwrap

### DIFF
--- a/patch-db/src/bulk_locks.rs
+++ b/patch-db/src/bulk_locks.rs
@@ -120,8 +120,8 @@ where
     pub async fn set<DH: DbHandle>(&self, db_handle: &mut DH, new_value: T) -> Result<(), Error> {
         self.set_(db_handle, new_value, &[]).await
     }
-    pub async fn get<DH: DbHandle>(&self, db_handle: &mut DH) -> Result<Option<T>, Error> {
-        self.get_(db_handle, &[]).await
+    pub async fn get<DH: DbHandle>(&self, db_handle: &mut DH) -> Result<T, Error> {
+        self.get_(db_handle, &[]).await.and_then(|x| x.map(Ok).unwrap_or_else(|| serde_json::from_value(serde_json::Value::Null).map_err(Error::JSON)))
     }
 }
 impl<T> LockReceipt<T, String>

--- a/patch-db/src/bulk_locks.rs
+++ b/patch-db/src/bulk_locks.rs
@@ -121,7 +121,11 @@ where
         self.set_(db_handle, new_value, &[]).await
     }
     pub async fn get<DH: DbHandle>(&self, db_handle: &mut DH) -> Result<T, Error> {
-        self.get_(db_handle, &[]).await.and_then(|x| x.map(Ok).unwrap_or_else(|| serde_json::from_value(serde_json::Value::Null).map_err(Error::JSON)))
+        self.get_(db_handle, &[]).await.and_then(|x| {
+            x.map(Ok).unwrap_or_else(|| {
+                serde_json::from_value(serde_json::Value::Null).map_err(Error::JSON)
+            })
+        })
     }
 }
 impl<T> LockReceipt<T, String>

--- a/patch-db/src/bulk_locks.rs
+++ b/patch-db/src/bulk_locks.rs
@@ -120,8 +120,8 @@ where
     pub async fn set<DH: DbHandle>(&self, db_handle: &mut DH, new_value: T) -> Result<(), Error> {
         self.set_(db_handle, new_value, &[]).await
     }
-    pub async fn get<DH: DbHandle>(&self, db_handle: &mut DH) -> Result<T, Error> {
-        self.get_(db_handle, &[]).await.map(|x| x.unwrap())
+    pub async fn get<DH: DbHandle>(&self, db_handle: &mut DH) -> Result<Option<T>, Error> {
+        self.get_(db_handle, &[]).await
     }
 }
 impl<T> LockReceipt<T, String>


### PR DESCRIPTION
## About

So, we shouldn't have unwraps in the code. In this case returning the option like the other gets makes the api more consistent

## Proof Of Fix

@chrisguida got his machine working when he built from the embassy-os branch.

## Related PR

https://github.com/Start9Labs/embassy-os/pull/1481