### PR TITLE
add cli utility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "patch-db",
     "patch-db-macro",
     "patch-db-macro-internals",
+    "patch-db-util",
     "cbor",
     "json-patch",
     "json-ptr",

--- a/patch-db-util/Cargo.toml
+++ b/patch-db-util/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "patch-db-util"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap = "3.2.16"
+patch-db = { path = "../patch-db" }
+serde_json = "1.0.85"
+tokio = { version = "1.20.1", features = ["full"] }

--- a/patch-db-util/src/main.rs
+++ b/patch-db-util/src/main.rs
@@ -1,0 +1,46 @@
+use std::path::Path;
+
+use patch_db::json_ptr::{JsonPointer, PtrSegment};
+use serde_json::Value;
+
+#[tokio::main]
+async fn main() {
+    let mut app = clap::App::new("patch-db-util")
+        .subcommand(
+            clap::Command::new("dump").arg(
+                clap::Arg::new("PATH")
+                    .required(true)
+                    .help("Path to the database file"),
+            ),
+        )
+        .subcommand(
+            clap::Command::new("from-dump").arg(
+                clap::Arg::new("PATH")
+                    .required(true)
+                    .help("Path to the database file"),
+            ),
+        );
+
+    match app.clone().get_matches().subcommand() {
+        Some(("dump", matches)) => {
+            let path = matches.value_of("PATH").unwrap();
+            let db = patch_db::PatchDb::open(path).await.unwrap();
+            let dump = db.dump().await;
+            serde_json::to_writer_pretty(&mut std::io::stdout(), &dump.value).unwrap();
+            println!();
+        }
+        Some(("from-dump", matches)) => {
+            let path = matches.value_of("PATH").unwrap();
+            let value: Value = serde_json::from_reader(&mut std::io::stdin()).unwrap();
+            let db = patch_db::PatchDb::open(path).await.unwrap();
+            db.put(
+                &JsonPointer::<&str, (&[PtrSegment], &[PtrSegment])>::default(),
+                &value,
+                None,
+            )
+            .await
+            .unwrap();
+        }
+        _ => app.print_long_help().unwrap(),
+    }
+}


### PR DESCRIPTION
closes https://github.com/Start9Labs/embassy-os/issues/762

## usage: 

to dump db:
```
patch-db-util dump /embassy-data/main/embassy.db > dump.json
```

to overwrite db:
```
patch-db-util from-dump /embassy-data/main/embassy.db < dump.json
```

to update db with jq:
```
patch-db-util dump /embassy-data/main/embassy.db | jq '["server-info"].hostname = "my-embassy"' | patch-db-util from-dump /embassy-data/main/embassy.db
```